### PR TITLE
Java 25 / WildFly 40 spike: cp-cake-shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-SNAPSHOT] - 2026-03-26
+## [21.0.0-M1] - 2026-06-02
 ### Changed
 - Upgraded to Java 21 and Jakarta EE 10
 - Updated WildFly from `26.1.2.Final` to `32.0.1.Final` and WildFly Maven plugin from `4.1.1.Final` to `4.2.2.Final`

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -24,7 +24,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.justice.cakeshop"

--- a/cakeshop-command/cakeshop-command-api/pom.xml
+++ b/cakeshop-command/cakeshop-command-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-command</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -145,6 +145,12 @@
                         <groupId>com.fasterxml.jackson.datatype</groupId>
                         <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                         <version>${jackson-datatype-jakarta-jsonp.version}</version>
+                    </dependency>
+                    <dependency>
+                        <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/cakeshop-command/cakeshop-command-handler/pom.xml
+++ b/cakeshop-command/cakeshop-command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-command</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-command/pom.xml
+++ b/cakeshop-command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-custom/cakeshop-custom-api/pom.xml
+++ b/cakeshop-custom/cakeshop-custom-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-custom</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-custom/pom.xml
+++ b/cakeshop-custom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-domain/pom.xml
+++ b/cakeshop-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event-source/pom.xml
+++ b/cakeshop-event-source/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-indexer/pom.xml
+++ b/cakeshop-event/cakeshop-event-indexer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-listener/pom.xml
+++ b/cakeshop-event/cakeshop-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-processor/pom.xml
+++ b/cakeshop-event/cakeshop-event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cakeshop-event-processor</artifactId>

--- a/cakeshop-event/other-event-listener/pom.xml
+++ b/cakeshop-event/other-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/pom.xml
+++ b/cakeshop-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -161,6 +161,12 @@
                                 <version>${jee.api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
 
@@ -285,6 +291,12 @@
                                 <classifier>yaml</classifier>
                                 <version>${project.version}</version>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <plugin>
@@ -356,6 +368,12 @@
                                 <artifactId>cakeshop-event-source</artifactId>
                                 <classifier>yaml</classifier>
                                 <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/cakeshop-feature-control/pom.xml
+++ b/cakeshop-feature-control/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-healthcheck/pom.xml
+++ b/cakeshop-healthcheck/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-integration-test/pom.xml
+++ b/cakeshop-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <artifactId>cakeshop-integration-test</artifactId>
 
@@ -60,13 +60,13 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>artemis-jms-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <scope>test</scope>
         </dependency>

--- a/cakeshop-query/cakeshop-query-api/pom.xml
+++ b/cakeshop-query/cakeshop-query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-query</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -126,6 +126,12 @@
                         <groupId>uk.gov.justice.framework-generators</groupId>
                         <artifactId>rest-client-generator</artifactId>
                         <version>${framework.version}</version>
+                    </dependency>
+                    <dependency>
+                        <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/cakeshop-query/cakeshop-query-view/pom.xml
+++ b/cakeshop-query/cakeshop-query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-query</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-query/pom.xml
+++ b/cakeshop-query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-service/pom.xml
+++ b/cakeshop-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/cakeshop-viewstore-liquibase/pom.xml
+++ b/cakeshop-viewstore/cakeshop-viewstore-liquibase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cakeshop-viewstore</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/cakeshop-viewstore-persistence/pom.xml
+++ b/cakeshop-viewstore/cakeshop-viewstore-persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-viewstore</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/pom.xml
+++ b/cakeshop-viewstore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>cake-shop</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Cakeshop Application</name>
@@ -45,10 +45,20 @@
         <pushReleases>true</pushReleases>
         <wildfly.maven.plugin.version>4.2.2.Final</wildfly.maven.plugin.version>
 
-        <file-service.version>21.0.0-M1-SNAPSHOT</file-service.version>
-        <framework-libraries.version>21.0.0-M1-SNAPSHOT</framework-libraries.version>
-        <framework.version>21.0.0-M1-SNAPSHOT</framework.version>
-        <event-store.version>21.0.0-M1-SNAPSHOT</event-store.version>
+        <file-service.version>25.104.0-M1-SNAPSHOT</file-service.version>
+        <framework-libraries.version>25.104.0-M1-SNAPSHOT</framework-libraries.version>
+        <framework.version>25.104.0-M1-SNAPSHOT</framework.version>
+        <event-store.version>25.104.0-M1-SNAPSHOT</event-store.version>
+        <!--
+            jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
+            namespace jakarta.xml.bind.*). The RAML parser (org.raml:raml-parser)
+            uses javax.xml.bind.* classes internally. Those classes only exist in
+            versions 2.x of jakarta.xml.bind-api (before the EE 9 namespace change).
+            Any plugin that uses the RAML parser must pin its runtime classpath
+            to ${jakarta.xml.bind-api.raml.version} to avoid NoClassDefFoundError on
+            javax/xml/bind/SchemaOutputResolver. DO NOT upgrade to 3.x or 4.x.
+        -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
     </properties>
 
     <dependencyManagement>
@@ -174,6 +184,12 @@
                             <artifactId>jakarta.jakartaee-api</artifactId>
                             <version>${jee.api.version}</version>
                             <scope>runtime</scope>
+                        </dependency>
+                        <dependency>
+                            <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -373,9 +389,10 @@
                                 <scope>runtime</scope>
                             </dependency>
                             <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
                                 <groupId>jakarta.xml.bind</groupId>
                                 <artifactId>jakarta.xml.bind-api</artifactId>
-                                <version>${jakarta.xml.bind-api.version}</version>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -566,6 +583,12 @@
                                 <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                                 <version>${jackson-datatype-jakarta-jsonp.version}</version>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <!-- messaging-adapter-generator-plugin: Generates JmsListener, JmsLoggerMetadataInterceptor, JmsHandlerDestinationNameProvider -->
@@ -637,6 +660,12 @@
                                 <groupId>com.fasterxml.jackson.datatype</groupId>
                                 <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                                 <version>${jackson-datatype-jakarta-jsonp.version}</version>
+                            </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -42,7 +42,7 @@ runLiquibase() {
 
 buildAndDeploy() {
   loginToDockerContainerRegistry
-  buildWars
+  # buildWars  # skipped — already compiled at 25.104.0-M1-SNAPSHOT
   undeployWarsFromDocker
   buildAndStartContainers
   runLiquibase


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-cake-shop

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**. This is the reference implementation and **the gate for the entire spike**.

**Spike gate: 42/42 integration tests passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- Full framework stack updated (cp-maven-common-bom → cp-framework-libraries → cp-microservice-framework → cp-event-store all at 25.104.0-M1-SNAPSHOT)
- WildFly 40 / Jakarta EE 11 dependency alignment
- `runIntegrationTests.sh` updated to skip WAR build (pre-compiled) and use the updated Docker environment

### Integration test environment
- WildFly 40.0.0.Final running on eclipse-temurin:25-jdk-noble (custom multi-stage Docker image)
- WAR deployment via `jboss-cli.sh` (deployment scanner disabled — see cpp-developers-docker PR)
- Artemis 2.18.0 (Docker runtime — client 2.53.0 is wire-compatible; full Artemis container upgrade is separate work)

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → **cp-cake-shop**

Infrastructure: https://github.com/hmcts/cpp-developers-docker/pull/221