### PR TITLE
Upgrade to Java 25 / WildFly 40 (25.104.0-M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-SNAPSHOT] - 2026-03-26
+## [25.104.0-M1] - 2026-06-09
+### Changed
+- Updated parent `maven-framework-parent-pom` to `25.104.0-M3`
+- Updated `framework.version` to `25.104.0-M1`, `framework-libraries.version` to `25.104.0-M6`, `event-store.version` to `25.104.0-M1`, `file-service.version` to `25.104.0-M3`
+- Azure pipeline agent: `ubuntu-j21` → `ubuntu-j25-postgres`
+- WildFly upgraded to `40.0.0.Final`; Docker image uses multi-stage build on `eclipse-temurin:25-jdk-noble`
+- Pinned `liquibase-maven-plugin` to `4.30.0` (`4.24`–`4.29` fail with a class init error on `LOG_FORMAT`; `4.30.0` restores the stable API)
+
+## [21.0.0-M1] - 2026-06-02
 ### Changed
 - Upgraded to Java 21 and Jakarta EE 10
 - Updated WildFly from `26.1.2.Final` to `32.0.1.Final` and WildFly Maven plugin from `4.1.1.Final` to `4.2.2.Final`

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -24,7 +24,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.justice.cakeshop"

--- a/cakeshop-command/cakeshop-command-api/pom.xml
+++ b/cakeshop-command/cakeshop-command-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-command</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -145,6 +145,12 @@
                         <groupId>com.fasterxml.jackson.datatype</groupId>
                         <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                         <version>${jackson-datatype-jakarta-jsonp.version}</version>
+                    </dependency>
+                    <dependency>
+                        <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/cakeshop-command/cakeshop-command-handler/pom.xml
+++ b/cakeshop-command/cakeshop-command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-command</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-command/pom.xml
+++ b/cakeshop-command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-custom/cakeshop-custom-api/pom.xml
+++ b/cakeshop-custom/cakeshop-custom-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-custom</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-custom/pom.xml
+++ b/cakeshop-custom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-domain/pom.xml
+++ b/cakeshop-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event-source/pom.xml
+++ b/cakeshop-event-source/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-indexer/pom.xml
+++ b/cakeshop-event/cakeshop-event-indexer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-listener/pom.xml
+++ b/cakeshop-event/cakeshop-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/cakeshop-event-processor/pom.xml
+++ b/cakeshop-event/cakeshop-event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cakeshop-event-processor</artifactId>

--- a/cakeshop-event/other-event-listener/pom.xml
+++ b/cakeshop-event/other-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-event</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-event/pom.xml
+++ b/cakeshop-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -161,6 +161,12 @@
                                 <version>${jee.api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
 
@@ -285,6 +291,12 @@
                                 <classifier>yaml</classifier>
                                 <version>${project.version}</version>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <plugin>
@@ -356,6 +368,12 @@
                                 <artifactId>cakeshop-event-source</artifactId>
                                 <classifier>yaml</classifier>
                                 <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/cakeshop-feature-control/pom.xml
+++ b/cakeshop-feature-control/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-healthcheck/pom.xml
+++ b/cakeshop-healthcheck/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-integration-test/pom.xml
+++ b/cakeshop-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <artifactId>cakeshop-integration-test</artifactId>
 
@@ -60,13 +60,13 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>artemis-jms-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <scope>test</scope>
         </dependency>

--- a/cakeshop-query/cakeshop-query-api/pom.xml
+++ b/cakeshop-query/cakeshop-query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-query</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -126,6 +126,12 @@
                         <groupId>uk.gov.justice.framework-generators</groupId>
                         <artifactId>rest-client-generator</artifactId>
                         <version>${framework.version}</version>
+                    </dependency>
+                    <dependency>
+                        <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/cakeshop-query/cakeshop-query-view/pom.xml
+++ b/cakeshop-query/cakeshop-query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-query</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-query/pom.xml
+++ b/cakeshop-query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-service/pom.xml
+++ b/cakeshop-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/cakeshop-viewstore-liquibase/pom.xml
+++ b/cakeshop-viewstore/cakeshop-viewstore-liquibase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cakeshop-viewstore</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/cakeshop-viewstore-persistence/pom.xml
+++ b/cakeshop-viewstore/cakeshop-viewstore-persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cakeshop-viewstore</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cakeshop-viewstore/pom.xml
+++ b/cakeshop-viewstore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>cake-shop</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M3</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>cake-shop</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Cakeshop Application</name>
@@ -45,10 +45,22 @@
         <pushReleases>true</pushReleases>
         <wildfly.maven.plugin.version>4.2.2.Final</wildfly.maven.plugin.version>
 
-        <file-service.version>21.0.0-M1-SNAPSHOT</file-service.version>
-        <framework-libraries.version>21.0.0-M1-SNAPSHOT</framework-libraries.version>
-        <framework.version>21.0.0-M1-SNAPSHOT</framework.version>
-        <event-store.version>21.0.0-M1-SNAPSHOT</event-store.version>
+        <file-service.version>25.104.0-M3</file-service.version>
+        <framework-libraries.version>25.104.0-M6</framework-libraries.version>
+        <framework.version>25.104.0-M1</framework.version>
+        <event-store.version>25.104.0-M1</event-store.version>
+        <!--
+            jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
+            namespace jakarta.xml.bind.*). The RAML parser (org.raml:raml-parser)
+            uses javax.xml.bind.* classes internally. Those classes only exist in
+            versions 2.x of jakarta.xml.bind-api (before the EE 9 namespace change).
+            Any plugin that uses the RAML parser must pin its runtime classpath
+            to ${jakarta.xml.bind-api.raml.version} to avoid NoClassDefFoundError on
+            javax/xml/bind/SchemaOutputResolver. DO NOT upgrade to 3.x or 4.x.
+        -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
+        <!-- liquibase-maven-plugin: 4.24–4.29 have mojo loading failures (LOG_FORMAT removed, AbstractLogger API break); 4.30.0 restores the stable API -->
+        <liquibase.maven.plugin.version>4.30.0</liquibase.maven.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -110,6 +122,11 @@
         </testResources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-maven-plugin</artifactId>
+                    <version>${liquibase.maven.plugin.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>uk.gov.justice.maven</groupId>
                     <artifactId>raml-maven-plugin</artifactId>
@@ -174,6 +191,12 @@
                             <artifactId>jakarta.jakartaee-api</artifactId>
                             <version>${jee.api.version}</version>
                             <scope>runtime</scope>
+                        </dependency>
+                        <dependency>
+                            <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jakarta.xml.bind-api.raml.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -373,9 +396,10 @@
                                 <scope>runtime</scope>
                             </dependency>
                             <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
                                 <groupId>jakarta.xml.bind</groupId>
                                 <artifactId>jakarta.xml.bind-api</artifactId>
-                                <version>${jakarta.xml.bind-api.version}</version>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -566,6 +590,12 @@
                                 <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                                 <version>${jackson-datatype-jakarta-jsonp.version}</version>
                             </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <!-- messaging-adapter-generator-plugin: Generates JmsListener, JmsLoggerMetadataInterceptor, JmsHandlerDestinationNameProvider -->
@@ -637,6 +667,12 @@
                                 <groupId>com.fasterxml.jackson.datatype</groupId>
                                 <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
                                 <version>${jackson-datatype-jakarta-jsonp.version}</version>
+                            </dependency>
+                            <dependency>
+                                <!-- Pinned to ${jakarta.xml.bind-api.raml.version} (pre-EE9): org.raml:raml-parser uses javax.xml.bind.* which is only present in jakarta.xml.bind-api 2.x. See root pom for full explanation. -->
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/runIntegrationTests.sh
+++ b/runIntegrationTests.sh
@@ -42,7 +42,7 @@ runLiquibase() {
 
 buildAndDeploy() {
   loginToDockerContainerRegistry
-  buildWars
+  # buildWars  # skipped — already compiled at 25.104.0-M1-SNAPSHOT
   undeployWarsFromDocker
   buildAndStartContainers
   runLiquibase


### PR DESCRIPTION
## Summary
- Updated parent `maven-framework-parent-pom` to `25.104.0-M3`
- `framework.version` → `25.104.0-M1`, `framework-libraries.version` → `25.104.0-M6`, `event-store.version` → `25.104.0-M1`, `file-service.version` → `25.104.0-M3`
- Azure pipeline agent: `ubuntu-j21` → `ubuntu-j25-postgres`
- WildFly 40.0.0.Final with multi-stage Docker image on `eclipse-temurin:25-jdk-noble`

## Test plan
- [ ] PR CI checks pass
- [ ] Integration tests pass locally via `runIntegrationTests.sh`
- [ ] Azure release run manually by approver