### PR TITLE
Consume released framework chain M8/M7/M11/M4/M5 (validation gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 ### Changed
-- Updated `framework.version` to `25.104.0-M3` (brings the relocated `persistence-jpa` module — the event-stream self-healing `EntityManagerFlushInterceptor` and `EntityManagerProducer`), `event-store.version` to `25.104.0-M4`, and parent `maven-framework-parent-pom` to `25.104.0-M7`
+- Consumed the released framework chain: parent `maven-framework-parent-pom` `25.104.0-M8`, `framework.version` (microservice-framework) `25.104.0-M4`, `event-store.version` `25.104.0-M5`, `framework-libraries.version` `25.104.0-M11`, and `file-service.version` `25.104.0-M7`. Brings Jackson `2.21.5` (**CVE-2026-54515**), the `org.junit:junit-bom` import, the relocated `persistence-jpa` module (event-stream self-healing `EntityManagerFlushInterceptor` + `EntityManagerProducer`), and the new event-store `EntityManagerFlushInterceptorPresenceVerifier` deploy-guard
 - `cakeshop-viewstore-persistence` now depends on `persistence-jpa`, delivering the flush interceptor and EntityManager producer into the service WARs
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>25.104.0-M7</version>
+        <version>25.104.0-M8</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
@@ -45,10 +45,10 @@
         <pushReleases>true</pushReleases>
         <wildfly.maven.plugin.version>4.2.2.Final</wildfly.maven.plugin.version>
 
-        <file-service.version>25.104.0-M3</file-service.version>
-        <framework-libraries.version>25.104.0-M6</framework-libraries.version>
-        <framework.version>25.104.0-M3</framework.version>
-        <event-store.version>25.104.0-M4</event-store.version>
+        <file-service.version>25.104.0-M7</file-service.version>
+        <framework-libraries.version>25.104.0-M11</framework-libraries.version>
+        <framework.version>25.104.0-M4</framework.version>
+        <event-store.version>25.104.0-M5</event-store.version>
         <!--
             jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
             namespace jakarta.xml.bind.*). The RAML parser (org.raml:raml-parser)


### PR DESCRIPTION
## Summary

Advances **cp-cake-shop** (the framework reference implementation) onto the milestones released in this framework cycle, and validates the whole released chain end-to-end.

### Version bumps
| ref | from | to |
|---|---|---|
| parent `maven-framework-parent-pom` | 25.104.0-M7 | **M8** |
| `file-service.version` | 25.104.0-M3 | **M7** |
| `framework-libraries.version` | 25.104.0-M6 | **M11** |
| `framework.version` (microservice-framework) | 25.104.0-M3 | **M4** |
| `event-store.version` | 25.104.0-M4 | **M5** |

These all had to move together — microservice-framework M4 / framework-libraries M11 transitively pull file-service M7 and framework-libraries M11, so leaving the explicit pins stale would trip `dependencyConvergence`.

The headline pickups across the chain: Jackson `2.21.5` (**CVE-2026-54515**), the `org.junit:junit-bom` import, and the new event-store **`EntityManagerFlushInterceptorPresenceVerifier`** deploy-guard.

## Validation (framework-level gate)

- Full reactor `mvn clean install` — **BUILD SUCCESS**.
- `runIntegrationTests.sh` — **BUILD SUCCESS**; deployed-app IT suite **42 tests, 0 failures, 0 errors, 0 skipped**.
- `StreamErrorHandlingIT` passes — exercises the new event-store flush-interceptor presence guard against a live deployment.

## Notes
- This is the reference-app validation for the framework chain, not a product release. cake-shop does **not** depend on the platform/ES chain, so that is out of scope here.
